### PR TITLE
fix: remove v prefix from release-please tags and release names

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-component-in-tag": false,
+  "include-v-in-tag": false,
   "changelog-path": "notes/CHANGELOG.md",
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

- Adds `"include-v-in-tag": false` to `.github/release-please/release-please-config.json`
- Future releases will tag as bare version numbers (e.g. `2.1.3`) instead of `v2.1.3`
- GitHub release names will follow suit — no `v` prefix

## Test plan

- [ ] Merge and verify the next release-please PR generates a tag without the `v` prefix
- [ ] Confirm the GitHub release name matches (e.g. `2.1.3`, not `v2.1.3`)

https://claude.ai/code/session_011FTgUN9ybdeeFznxhFHFj6

---
_Generated by [Claude Code](https://claude.ai/code/session_011FTgUN9ybdeeFznxhFHFj6)_