### PR TITLE
fix: cursor placement broken by heading .cm-line overrides

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1664,8 +1664,12 @@ select:focus,
    MARKDOWN HEADERS - GitHub-style with underlines
    ───────────────────────────────────────────────────────────────────────── */
 
-h1,
-.cm-header-1 {
+/* h1/h2 border-bottom & padding-bottom intentionally NOT applied to
+   .cm-header-1/.cm-header-2 (the inline heading-token span inside a CM6
+   .cm-line): the containing .cm-line.HyperMD-header-1/2 rule below already
+   draws that border for edit mode. Applying it to both produced a visible
+   double underline. */
+h1 {
     display: block;
     padding-bottom: .3em;
     border-bottom: 1px solid var(--color-base-50);
@@ -1673,8 +1677,7 @@ h1,
     margin-bottom: 16px;
 }
 
-h2,
-.cm-header-2 {
+h2 {
     display: block;
     padding-bottom: .3em;
     border-bottom: 1px solid var(--color-base-50);
@@ -1714,16 +1717,12 @@ h6,
     margin-bottom: 16px;
 }
 
-/* Match GitHub spacing for editing mode */
-.markdown-source-view.mod-cm6 .cm-line.HyperMD-header-1,
-.markdown-source-view.mod-cm6 .cm-line.HyperMD-header-2,
-.markdown-source-view.mod-cm6 .cm-line.HyperMD-header-3,
-.markdown-source-view.mod-cm6 .cm-line.HyperMD-header-4,
-.markdown-source-view.mod-cm6 .cm-line.HyperMD-header-5,
-.markdown-source-view.mod-cm6 .cm-line.HyperMD-header-6 {
-    margin-top: 16px !important;
-    margin-bottom: 12px !important;
-}
+/* Match GitHub spacing for editing mode.
+   margin-top/bottom removed here: forcing margins on .cm-line via !important
+   changes the element's rendered box height/position independently of what
+   CodeMirror 6 has cached for line layout, which desyncs its coordinate-to-
+   position mapping and breaks click/arrow-key cursor placement on lines
+   below a heading (see #10). */
 
 /* Full-width borders for H1/H2 in editing mode */
 .markdown-source-view.mod-cm6 .cm-line.HyperMD-header-1,


### PR DESCRIPTION
## Summary
- CM6's `.cm-line` element carries CodeMirror's own cached line-height/position measurements, which it uses to map click coordinates and arrow-key navigation back to document positions. The theme was forcing `margin-top`/`margin-bottom !important` (and, for H1/H2, `border-bottom`/`padding-bottom !important`) directly onto `.cm-line.HyperMD-header-*`, changing the line's actual rendered height out from under CodeMirror's cache.
- That desync caused clicks to place the cursor in the wrong spot and up/down arrow to skip lines, most reliably reproduced by clicking into a paragraph immediately following a heading.
- Removed the `!important` margin override on `.cm-line.HyperMD-header-*` entirely — CM6's own default line spacing is used instead.
- While testing, found the H1/H2 border-bottom underline was being drawn twice (once on the `.cm-header-1`/`.cm-header-2` inline token, once on the containing `.cm-line`), producing a visible double underline in edit mode. Scoped the border/padding to `h1`/`h2` (preview) only, since edit mode already gets its border from the `.cm-line.HyperMD-header-1/2` rule.

Fixes #10

## Test plan
- [x] Pasted the repro file from #10 into a new note
- [x] Clicked into the last paragraph (following an `### h3`) — cursor now lands where clicked
- [x] Pressed Up from end of document — cursor moves one line at a time, no skipping
- [x] Confirmed H1/H2 underline renders as a single line in both edit and preview mode
- [ ] Reporter re-test on their original environment (Linux Mint 22.2, Obsidian 1.10.6)