### PR TITLE
fix: correct Discord invite link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 - GitHub Issues: [Report an issue](https://github.com/ScottKirvan/GitHubDHC/issues)
 - LinkedIn: [linkedin.com/in/scottkirvan/](https://www.linkedin.com/in/scottkirvan/)
-- Discord: [discord.gg/TSKHvVFYxB](https://discord.gg/TSKHvVFYxB)
+- Discord: [discord.gg/TN6XJSNK5Y](https://discord.gg/TN6XJSNK5Y)
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,6 @@ When making changes to the template initialization workflow, test by:
 
 Feel free to open an issue for questions or reach out via:
 - [LinkedIn](https://www.linkedin.com/in/scottkirvan/)
-- [Discord](https://discord.gg/TSKHvVFYxB)
+- [Discord](https://discord.gg/TN6XJSNK5Y)
 
 Thank you for your contributions!


### PR DESCRIPTION
Replaces incorrect invite code `TSKHvVFYxB` with correct `TN6XJSNK5Y` in CODE_OF_CONDUCT.md and CONTRIBUTING.md.