### PR TITLE
chore: remove per-repo FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-github: ScottKirvan
-buy_me_a_coffee: scottkirvan
-patreon: scottkirvan


### PR DESCRIPTION
## Summary
- Deletes per-repo FUNDING.yml — central ScottKirvan/.github FUNDING.yml (Ko-Fi + GitHub Sponsors) now applies automatically

## Type of Change
- [x] CI / tooling / workflow change