### PR TITLE
fix: pass discord_blurb to discord notify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,4 +73,5 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "GitHubDHC"
       emoji: "🎨"
+      discord_blurb: ${{ needs.improve-release-notes.outputs.discord_blurb }}
     secrets: inherit


### PR DESCRIPTION
Depends on ScottKirvan/.github#25. Adds `discord_blurb` passthrough so the Discord notification uses the pre-generated punchy blurb instead of extracting from the release body.