### PR TITLE
fix: move link banner to header, add Ko-Fi, update context, add preview workflow

### DIFF
--- a/.github/workflows/preview-release-notes.yml
+++ b/.github/workflows/preview-release-notes.yml
@@ -1,0 +1,32 @@
+name: Manual — Preview Release Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Anticipated next version tag (e.g. v1.2.0) — need not exist yet
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  models: read
+
+jobs:
+  preview:
+    uses: ScottKirvan/.github/.github/workflows/reusable-preview-release-notes.yml@main
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      project_name: "GitHubDHC"
+      project_context: "GitHubDHC is a high-contrast dark theme for Obsidian, designed for users who want a clean, precise visual environment for reading and writing. It brings GitHub's Dark High Contrast palette to Obsidian's interface. Changes typically affect readability, element contrast, or how specific UI components look — write in terms of how the user's visual experience improves."
+      header: |
+        ## GitHubDHC
+
+        > A high-contrast dark theme for Obsidian, inspired by GitHub's Dark High Contrast interface.
+
+        🫶❤️[Support this project](https://ko-fi.com/ScottKirvan) · 📖 [User Guide](https://www.scottkirvan.com/GitHubDHC/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/GitHubDHC/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/GitHubDHC/issues/new?template=feature_request.md) · 📋 [Changelog](https://github.com/ScottKirvan/GitHubDHC/blob/main/notes/CHANGELOG.md)
+
+        ---
+      footer: ""
+      changelog_path: ""
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,4 +73,5 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "GitHubDHC"
       emoji: "🎨"
+      discord_blurb: ${{ needs.improve-release-notes.outputs.discord_blurb }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
   workflow_dispatch:
 
+
 permissions:
   contents: write
   pull-requests: write
@@ -46,16 +47,17 @@ jobs:
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "GitHubDHC"
-      project_context: "GitHubDHC is an Obsidian theme inspired by the GitHub Dark High Contrast theme, providing a high-contrast dark interface for Obsidian."
+      project_context: "GitHubDHC is a high-contrast dark theme for Obsidian, designed for users who want a clean, precise visual environment for reading and writing. It brings GitHub's Dark High Contrast palette to Obsidian's interface. Changes typically affect readability, element contrast, or how specific UI components look — write in terms of how the user's visual experience improves."
       header: |
         ## GitHubDHC
 
         > A high-contrast dark theme for Obsidian, inspired by GitHub's Dark High Contrast interface.
 
+        🫶❤️[Support this project](https://ko-fi.com/ScottKirvan) · 📖 [User Guide](https://www.scottkirvan.com/GitHubDHC/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/GitHubDHC/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/GitHubDHC/issues/new?template=feature_request.md) · 📋 [Changelog](https://github.com/ScottKirvan/GitHubDHC/blob/main/notes/CHANGELOG.md)
+
         ---
-      footer: |
-        ---
-        📖 [User Guide](https://www.scottkirvan.com/GitHubDHC/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/GitHubDHC/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/GitHubDHC/issues/new?template=feature_request.md)
+      footer: ""
+      changelog_path: ""
     secrets: inherit
 
   update-changelog-prs:


### PR DESCRIPTION
## Summary
- Moves support/docs/discord link banner from footer into header section (below project tagline), matching BojuBot's layout
- Adds Ko-Fi support link as first item in banner
- Adds Changelog link to banner; clears `footer` and `changelog_path` to avoid duplication
- Updates `project_context` with audience-aware framing
- Adds `workflow_dispatch` trigger to release workflow
- Adds `preview-release-notes.yml` for previewing release notes before a release exists
- Wires `discord_blurb` passthrough to `discord-notify` job (curated AI blurb instead of fallback extraction)

## Test plan
- [ ] Trigger a release and verify header layout and link banner render correctly
- [ ] Run preview workflow to validate draft pre-release output
- [ ] Confirm Discord notification uses the curated blurb