### PR TITLE
Fix --canvas-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "GitHubDHC",
 	"version": "2.2.1",
-	"minAppVersion": "1.0.0",
+	"minAppVersion": "1.13.0",
 	"author": "Scott Kirvan",
 	"authorUrl": "https://github.com/ScottKirvan"
 }

--- a/theme.css
+++ b/theme.css
@@ -867,12 +867,12 @@ body {
     --canvas-dot-pattern: #3d444d;
     --canvas-card-label-color: var(--color-base-70);
     /* RGB triplets required — Obsidian uses rgba(var(--canvas-color-N), alpha) */
-    --canvas-color-1: 255, 148, 146;    /* #ff9492 red   */
-    --canvas-color-2: 255, 166, 87;     /* #ffa657 orange */
-    --canvas-color-3: 240, 183, 47;     /* #f0b72f yellow */
-    --canvas-color-4: 43, 216, 83;      /* #2bd853 green  */
-    --canvas-color-5: 165, 214, 255;    /* #a5d6ff cyan   */
-    --canvas-color-6: 210, 168, 255;    /* #d2a8ff purple */
+    --canvas-color-1: rgb(255, 148, 146);    /* #ff9492 red   */
+    --canvas-color-2: rgb(255, 166, 87);     /* #ffa657 orange */
+    --canvas-color-3: rgb(240, 183, 47);     /* #f0b72f yellow */
+    --canvas-color-4: rgb(43, 216, 83);      /* #2bd853 green  */
+    --canvas-color-5: rgb(165, 214, 255);    /* #a5d6ff cyan   */
+    --canvas-color-6: rgb(210, 168, 255);    /* #d2a8ff purple */
 }
 
 /*
@@ -1024,12 +1024,12 @@ body {
     --canvas-dot-pattern: #afb8c1;
     --canvas-card-label-color: var(--color-base-70);
     /* RGB triplets required — Obsidian uses rgba(var(--canvas-color-N), alpha) */
-    --canvas-color-1: 207, 34, 46;      /* #cf222e red   */
-    --canvas-color-2: 188, 76, 0;       /* #bc4c00 orange */
-    --canvas-color-3: 154, 103, 0;      /* #9a6700 yellow */
-    --canvas-color-4: 26, 127, 55;      /* #1a7f37 green  */
-    --canvas-color-5: 9, 105, 218;      /* #0969da cyan   */
-    --canvas-color-6: 130, 80, 223;     /* #8250df purple */
+    --canvas-color-1: rgb(207, 34, 46);      /* #cf222e red   */
+    --canvas-color-2: rgb(188, 76, 0);       /* #bc4c00 orange */
+    --canvas-color-3: rgb(154, 103, 0);      /* #9a6700 yellow */
+    --canvas-color-4: rgb(26, 127, 55);      /* #1a7f37 green  */
+    --canvas-color-5: rgb(9, 105, 218);      /* #0969da cyan   */
+    --canvas-color-6: rgb(130, 80, 223);     /* #8250df purple */
 }
 
 /*
@@ -1955,28 +1955,28 @@ svg.canvas-background circle {
 
 /* Colored card variants — border uses full color, background uses 10% alpha tint */
 .canvas-node[data-color="1"] .canvas-node-container {
-    border-color: rgb(var(--canvas-color-1));
-    background-color: rgba(var(--canvas-color-1), 0.1);
+    border-color: var(--canvas-color-1);
+    background-color: color-mix(in srgb, var(--canvas-color-1) 10%, transparent);
 }
 .canvas-node[data-color="2"] .canvas-node-container {
-    border-color: rgb(var(--canvas-color-2));
-    background-color: rgba(var(--canvas-color-2), 0.1);
+    border-color: var(--canvas-color-2);
+    background-color: color-mix(in srgb, var(--canvas-color-2) 10%, transparent);
 }
 .canvas-node[data-color="3"] .canvas-node-container {
-    border-color: rgb(var(--canvas-color-3));
-    background-color: rgba(var(--canvas-color-3), 0.1);
+    border-color: var(--canvas-color-3);
+    background-color: color-mix(in srgb, var(--canvas-color-3) 10%, transparent);
 }
 .canvas-node[data-color="4"] .canvas-node-container {
-    border-color: rgb(var(--canvas-color-4));
-    background-color: rgba(var(--canvas-color-4), 0.1);
+    border-color: var(--canvas-color-4);
+    background-color: color-mix(in srgb, var(--canvas-color-4) 10%, transparent);
 }
 .canvas-node[data-color="5"] .canvas-node-container {
-    border-color: rgb(var(--canvas-color-5));
-    background-color: rgba(var(--canvas-color-5), 0.1);
+    border-color: var(--canvas-color-5);
+    background-color: color-mix(in srgb, var(--canvas-color-5) 10%, transparent);
 }
 .canvas-node[data-color="6"] .canvas-node-container {
-    border-color: rgb(var(--canvas-color-6));
-    background-color: rgba(var(--canvas-color-6), 0.1);
+    border-color: var(--canvas-color-6);
+    background-color: color-mix(in srgb, var(--canvas-color-6) 10%, transparent);
 }
 
 /* Group containers */
@@ -1999,9 +1999,9 @@ svg.canvas-background circle {
 }
 
 /* Colored edges — parent <g> gets mod-canvas-color-N, child path is canvas-display-path */
-.mod-canvas-color-1 path.canvas-display-path { stroke: rgb(var(--canvas-color-1)); }
-.mod-canvas-color-2 path.canvas-display-path { stroke: rgb(var(--canvas-color-2)); }
-.mod-canvas-color-3 path.canvas-display-path { stroke: rgb(var(--canvas-color-3)); }
-.mod-canvas-color-4 path.canvas-display-path { stroke: rgb(var(--canvas-color-4)); }
-.mod-canvas-color-5 path.canvas-display-path { stroke: rgb(var(--canvas-color-5)); }
-.mod-canvas-color-6 path.canvas-display-path { stroke: rgb(var(--canvas-color-6)); }
+.mod-canvas-color-1 path.canvas-display-path { stroke: var(--canvas-color-1); }
+.mod-canvas-color-2 path.canvas-display-path { stroke: var(--canvas-color-2); }
+.mod-canvas-color-3 path.canvas-display-path { stroke: var(--canvas-color-3); }
+.mod-canvas-color-4 path.canvas-display-path { stroke: var(--canvas-color-4); }
+.mod-canvas-color-5 path.canvas-display-path { stroke: var(--canvas-color-5); }
+.mod-canvas-color-6 path.canvas-display-path { stroke: var(--canvas-color-6); }


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--canvas-color` (and `--canvas-color-1` through `--canvas-color-6`) works. It now provides a valid CSS color value (e.g. `#e93147`) instead of a bare RGB triplet (`233, 49, 71`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--canvas-color-1: 255, 0, 128;
/* After */
--canvas-color-1: rgb(255, 0, 128);
```

**2. Wrapping `var(--canvas-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--canvas-color), 0.1);
/* After */
background: color-mix(in srgb, var(--canvas-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--canvas-color` / `--canvas-color-N` declarations with `rgb()`
- Replaced `rgb(var(--canvas-color))` with `var(--canvas-color)`
- Replaced `rgba(var(--canvas-color), <alpha>)` with `color-mix(in srgb, var(--canvas-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
